### PR TITLE
devops: preparations for moving od-website to k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
-FROM alpine:3.22.1
+FROM node:alpine3.22
 
+COPY . .
+CMD ["npm", "start"] 
 
-RUN apk add --no-cache \
-        ca-certificates \
-        gcc \
-	      curl \
-        npm
-
-RUN mkdir website
-COPY ./src ./website/src 
-COPY ./build ./website/build 
-COPY ./public ./website/public 
-COPY ./package.json ./website/package.json 
-RUN cd website && npm i
-RUN cd website && npm start 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,15 @@ pipeline {
   stages {
     stage('Start Landing Page') {
       steps {
-        sh '\
-          npm i;\
-          JENKINS_NODE_COOKIE=dontKillMe npm start > ~/website.logs 2> ~/website_error.logs &' 
+        sh 'npm i'
+        sh 'docker compose up -d'
       }
+    }
+  }
+
+  post {
+    always {
+      sh 'rm -rf ./node_modules'
     }
   }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  node:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    user: "node"
+    working_dir: /home/node/app
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - ./:/home/node/app
+    ports:
+      - "127.0.0.1:3000:3000"


### PR DESCRIPTION
@OllieOlafsson  will be taking on the challenge of moving
this component to k8s. To help him do this we
have to dockerize it first... and then create
images based on it.

This commit simply makes the deployment of od-website
dockerized. Why wasn't this done earlier? Idk. I dont remember.